### PR TITLE
Remove the need to modify Xwrapper.config

### DIFF
--- a/init/kodi.service
+++ b/init/kodi.service
@@ -11,6 +11,7 @@ Type = simple
 TTYPath=/dev/tty7
 ExecStart = /usr/bin/xinit /usr/bin/dbus-launch --exit-with-session /usr/bin/kodi-standalone -- :0 -nolisten tcp vt7
 Restart = on-abort
+StandardInput = tty
 
 [Install]
 WantedBy = multi-user.target


### PR DESCRIPTION
Hello!

First, thanks a lot for this service file! I just found that, by adding this line, the created X server becomes the [controlling process](http://www.freedesktop.org/software/systemd/man/systemd.exec.html#StandardInput=) of the VT it is bound to, and that you don't need to modify `/etc/X11/Xwrapper.config` anymore ; just enable the service and it works!

This removes one step from the instructions in the [Wiki](https://wiki.archlinux.org/index.php/XBMC#Kodi-standalone-service), which is always nice. Anything you can see that prevents integration into your AUR package?
