### PR TITLE
Improve service file

### DIFF
--- a/init/kodi.service
+++ b/init/kodi.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Starts instance of Kodi using xinit
+Description=Kodi standalone
 After=systemd-user-sessions.service network-online.target sound.target mysqld.service
 Requires=network-online.target
 Conflicts=getty@tty1.service
@@ -14,4 +14,4 @@ Restart=on-abort
 StandardInput=tty
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=graphical.target


### PR DESCRIPTION
This solves two problems:

1. Currently if you want to boot to terminal with kernel parameter `systemd.unit=multi-user.target`, a kodi instance will get started. That should not happen. Kodi is a graphical application so it should only run in `graphical.target`. 

2. The unit description results in messages like this in the journal: `systemd[1]: Started Starts instance of Kodi using xinit.`. I replaced it with a more simpler "Kodi standalone" description.