### PR TITLE
Add kodi-gbm

### DIFF
--- a/init/kodi-gbm.service
+++ b/init/kodi-gbm.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Kodi standalone (GBM)
+After=systemd-user-sessions.service network.target network-online.target sound.target upower.service mysqld.service
+Requires=graphical.target
+Wants=network.target network-online.target
+Conflicts=getty@tty1.service
+
+[Service]
+User=kodi
+Group=kodi
+PAMName=login
+TTYPath=/dev/tty1
+Environment=WINDOWING=gbm
+ExecStart=/usr/bin/kodi-standalone
+Restart=on-abort
+StandardInput=tty
+
+[Install]
+WantedBy=graphical.target


### PR DESCRIPTION
This allows running Kodi directly off DRM/KMS without X server.

To use keyboard and mouse the `kodi` user needs to be a member of the `input` group.