### PR TITLE
Improve systemd units

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Users of Arch ARM should NOT use this method as the distro package provides anal
 ### Other distros
 Users of other distros should copy `kodi.service` and `kodi-gbm.service` to `/usr/lib/systemd/system/` and should create both a kodi user and home directory as follows:
 ```
- useradd -c 'kodi user' -u 420 -g kodi -G audio,input,network,optical,uucp,video \
+ useradd -c 'kodi user' -u 420 -g kodi -G audio,network,optical,uucp,video \
    -d /var/lib/kodi -s /usr/bin/nologin kodi
 
  passwd -l kodi > /dev/null

--- a/init/kodi-gbm.service
+++ b/init/kodi-gbm.service
@@ -1,13 +1,13 @@
 [Unit]
 Description=Kodi standalone (GBM)
-After=systemd-user-sessions.service network.target network-online.target sound.target upower.service mysqld.service
-Requires=graphical.target
-Wants=network.target network-online.target
+After=remote-fs.target systemd-user-sessions.service network-online.target nss-lookup.target sound.target bluetooth.target polkit.service upower.service mysqld.service
+Wants=network-online.target polkit.service upower.service
 Conflicts=getty@tty1.service
 
 [Service]
 User=kodi
 Group=kodi
+SupplementaryGroups=input
 PAMName=login
 TTYPath=/dev/tty1
 Environment=WINDOWING=gbm

--- a/init/kodi.service
+++ b/init/kodi.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Kodi standalone (X11)
-After=systemd-user-sessions.service network-online.target sound.target mysqld.service
-Requires=network-online.target
+After=remote-fs.target systemd-user-sessions.service network-online.target nss-lookup.target sound.target bluetooth.target polkit.service upower.service mysqld.service
+Wants=network-online.target polkit.service upower.service
 Conflicts=getty@tty1.service
 
 [Service]
@@ -9,6 +9,7 @@ User=kodi
 Group=kodi
 PAMName=login
 TTYPath=/dev/tty1
+Environment=WINDOWING=x11
 ExecStart=/usr/bin/xinit /usr/bin/kodi-standalone -- :0 -nolisten tcp vt1
 Restart=on-abort
 StandardInput=tty


### PR DESCRIPTION
Use the same dependencies and their order in both systemd units.
Add additional units of services that kodi uses.
Don't use `Requires=`, kodi can run without a network connection
Export `WINDOWING=x11` in `kodi.service` to skip the autodetection that `/usr/bin/kodi-standalone` performs.