### PR TITLE
Use systemd-tmpfiles and systemd-sysusers

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,16 +9,11 @@ Arch Linux users can find a PKGBUILD in the [AUR](https://aur.archlinux.org/pack
 Users of Arch ARM should NOT use this method as the distro package provides analogous functionality.
 
 ### Other distros
-Users of other distros should copy `kodi.service` and `kodi-gbm.service` to `/usr/lib/systemd/system/` and should create both a kodi user and home directory as follows:
-```
- useradd -c 'kodi user' -u 420 -g kodi -G audio,network,optical,uucp,video \
-   -d /var/lib/kodi -s /usr/bin/nologin kodi
+Users of other distros should install the following files:
 
- passwd -l kodi > /dev/null
-
- mkdir /var/lib/kodi
- chown -R kodi:kodi /var/lib/kodi
-```
+* `init/kodi.service` and `init/kodi-gbm.service` to `/usr/lib/systemd/system`
+* `sysusers.conf` to `/usr/lib/sysusers.d`, then run `systemd-sysusers`
+* `tmpfiles.conf` to `/usr/lib/tmpfiles.d`, then run `systemd-tmpfiles --create`
 
 Note that the kodi user's home directory is `/var/lib/kodi/` in this example, NOT `/home/kodi/` like a regular user.
 

--- a/sysusers.conf
+++ b/sysusers.conf
@@ -1,0 +1,10 @@
+# == System users ==
+#   user    uid   descr     home
+u   kodi    -     Kodi      /var/lib/kodi
+
+# == Group memberships ==
+#   user    group
+m   kodi    audio
+m   kodi    optical
+m   kodi    uucp
+m   kodi    video

--- a/tmpfiles.conf
+++ b/tmpfiles.conf
@@ -1,0 +1,1 @@
+d   /var/lib/kodi     0700    kodi  kodi  -


### PR DESCRIPTION
This MR introduces the usage of `systemd-tmpfiles` and `systemd-sysusers`. 

In `sysusers.conf`, the `kodi` user will be created with the corresponding group memberships. The UID will be chosen by systemd but won't be changed if the user is already present on the system. Its home will be set to `/var/lib/kodi`.

In `tmpfiles.conf`, the directory `/var/lib/kodi` will be created and its ownership gets assigned to `kodi`. This removes the need of installing the directory in Arch Linux' `PKGBUILD` file and doing `chown` stuff. 

I think this declarative approach is superior to scripting it manually or inside `PKGBUILD` for Arch. 

To incorporate these changes into the `PKGBUILD` from the AUR, these lines need to be added to each of the `package()` functions:

```shell
install -Dm644 sysusers.conf "$pkgdir"/usr/lib/sysusers.d/kodi.conf
install -Dm644 tmpfiles.conf "$pkgdir"/usr/lib/tmpfiles.d/kodi.conf
```

The post-install hooks from Pacman will pick the changes up automatically.