### PR TITLE
Add kodi-wayland.service

### DIFF
--- a/init/kodi-wayland.service
+++ b/init/kodi-wayland.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Kodi standalone (Wayland)
+After=remote-fs.target systemd-user-sessions.service network-online.target nss-lookup.target sound.target bluetooth.target polkit.service upower.service mysqld.service
+Wants=network-online.target polkit.service upower.service
+Conflicts=getty@tty1.service
+
+[Service]
+User=kodi
+Group=kodi
+PAMName=login
+TTYPath=/dev/tty1
+Environment=WINDOWING=wayland
+ExecStart=/usr/bin/cage -- /usr/bin/kodi-standalone
+Restart=on-abort
+StandardInput=tty
+StandardOutput=journal
+
+[Install]
+WantedBy=graphical.target


### PR DESCRIPTION
This allows running Kodi in a Wayland session using the [Cage](https://github.com/Hjdskes/cage) compositor.

VT switching doesn't work because unfortunately Cage doesn't support it. 

<details>
<summary>PKGBUILD changes:</summary>

```diff
diff --git a/PKGBUILD b/PKGBUILD
index 6d2f935..5c0aecd 100644
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: graysky <graysky AT archlinux DOT us>
 
 pkgbase=kodi-standalone-service
-pkgname=(kodi-standalone-service kodi-standalone-gbm-service)
+pkgname=(kodi-standalone-service kodi-standalone-gbm-service kodi-standalone-wayland-service)
 pkgver=1.102
 pkgrel=1
 pkgdesc="Systemd service to run kodi in stand-alone mode without a DE"
@@ -32,4 +32,13 @@ package_kodi-standalone-gbm-service() {
   install -Dm644 init/tmpfiles.conf "$pkgdir/usr/lib/tmpfiles.d/kodi-gbm.conf"
 }
 
+package_kodi-standalone-wayland-service() {
+  depends=('kodi-wayland' 'polkit' 'libinput' 'cage')
+
+  cd "$pkgbase-$pkgver"
+  install -Dm644 init/kodi-wayland.service "$pkgdir/usr/lib/systemd/system/kodi-wayland.service"
+  install -Dm644 init/sysusers.conf "$pkgdir/usr/lib/sysusers.d/kodi-wayland.conf"
+  install -Dm644 init/tmpfiles.conf "$pkgdir/usr/lib/tmpfiles.d/kodi-wayland.conf"
+}
+
 # vim:set ts=2 sw=2 et:
```

</details> 
