### PR TITLE
kodi-wayland: use runtime directory created by systemd

### DIFF
--- a/init/kodi-wayland.service
+++ b/init/kodi-wayland.service
@@ -7,7 +7,8 @@ Conflicts=getty@tty1.service
 [Service]
 User=kodi
 Group=kodi
-Environment="XDG_RUNTIME_DIR=/tmp"
+RuntimeDirectory=kodi
+Environment="XDG_RUNTIME_DIR=%t/kodi"
 EnvironmentFile=-/etc/conf.d/kodi-standalone
 TTYPath=/dev/tty1
 Environment=WINDOWING=wayland


### PR DESCRIPTION
This will sort out the permissions warning mentionned in #27.

The RuntimeDirectory is created in /run/kodi with the necessary
permissions, %t points at /run.

See systemd.exec(5) and systemd.unit(5).