### PR TITLE
switch to the output of 'uname -m' to detect ARM based systems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ INSTALL_DIR = $(INSTALL) -d
 INSTALL_PROGRAM = $(INSTALL) -m755
 INSTALL_DATA = $(INSTALL) -m644
 
-IS_ARCH_ARM := $(shell grep -q ARM /proc/cpuinfo; echo $$?)
+IS_ARCH_ARM := $(shell uname -m | grep -q -E "^(arm|aarch64)"; echo $$?)
 ifeq ($(IS_ARCH_ARM), 0)
 	ARCH = arm
 else


### PR DESCRIPTION
At least on RaspiOS 64Bit the contents of `/proc/cpuinfo` does not contain the string `ARM`. As an example here is the contents of the file on a CM4 running RaspiOS 64Bit Bullseye:
```
processor	: 0
BogoMIPS	: 108.00
Features	: fp asimd evtstrm crc32 cpuid
CPU implementer	: 0x41
CPU architecture: 8
CPU variant	: 0x0
CPU part	: 0xd08
CPU revision	: 3

processor	: 1
BogoMIPS	: 108.00
Features	: fp asimd evtstrm crc32 cpuid
CPU implementer	: 0x41
CPU architecture: 8
CPU variant	: 0x0
CPU part	: 0xd08
CPU revision	: 3

processor	: 2
BogoMIPS	: 108.00
Features	: fp asimd evtstrm crc32 cpuid
CPU implementer	: 0x41
CPU architecture: 8
CPU variant	: 0x0
CPU part	: 0xd08
CPU revision	: 3

processor	: 3
BogoMIPS	: 108.00
Features	: fp asimd evtstrm crc32 cpuid
CPU implementer	: 0x41
CPU architecture: 8
CPU variant	: 0x0
CPU part	: 0xd08
CPU revision	: 3

Hardware	: BCM2835
Revision	: c03140
Serial		: 10000000505e6164
Model		: Raspberry Pi Compute Module 4 Rev 1.0
```
In contrast to `/proc/cpuinfo` the output of `uname -m` will AFAIK always start with `arm` or `aarch64` for most if not all ARM based CPUs. For example current RaspiOS images will yield `armv7l` or `aarch64`. 